### PR TITLE
openssl.c: fix build with wolfssl

### DIFF
--- a/openssl.c
+++ b/openssl.c
@@ -71,13 +71,13 @@
                 "TLS13-AES256-GCM-SHA384:"		\
                 ecdhe_aead_ciphers
 #else
-# define tls13_ciphersuites	"TLS_CHACHA20_POLY1305_SHA256:"		\
-                "TLS_AES_128_GCM_SHA256:"		\
-                "TLS_AES_256_GCM_SHA384"
-
 # define top_ciphers							\
                 ecdhe_aead_ciphers
 #endif
+
+# define tls13_ciphersuites	"TLS_CHACHA20_POLY1305_SHA256:"		\
+                "TLS_AES_128_GCM_SHA256:"		\
+                "TLS_AES_256_GCM_SHA384"
 
 #define ecdhe_aead_ciphers						\
                 "ECDHE-ECDSA-CHACHA20-POLY1305:"	\


### PR DESCRIPTION
Fix the following build failure with wolfssl:

```
/tmp/instance-4/output-1/build/libuhttpd-3.12.1/src/ssl/openssl.c: In function 'ssl_context_new':
/tmp/instance-4/output-1/build/libuhttpd-3.12.1/src/ssl/openssl.c:174:33: error: 'tls13_ciphersuites' undeclared (first use in this function)
  174 |     SSL_CTX_set_ciphersuites(c, tls13_ciphersuites);
      |                                 ^~~~~~~~~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/d0fb629b40b05ad828775894fabed878692bb222

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>