### PR TITLE
add compatibility for wolfssl >= 5.0

### DIFF
--- a/openssl.c
+++ b/openssl.c
@@ -336,7 +336,9 @@ static bool handle_wolfssl_asn_error(void *ssl, int r,
     case ASN_SIG_HASH_E:
     case ASN_SIG_KEY_E:
     case ASN_DH_KEY_E:
+#if LIBWOLFSSL_VERSION_HEX < 0x05000000
     case ASN_NTRU_KEY_E:
+#endif
     case ASN_CRIT_EXT_E:
     case ASN_ALT_NAME_E:
     case ASN_NO_PEM_HEADER:


### PR DESCRIPTION
NTRU support has been removed in wolfssl 5.0 so it is required to
mask NTRU specific code if wolfssl >= 5.0

Signed-off-by: Sergey V. Lobanov <sergey at lobanov.in>