### PR TITLE
CMakeLists.txt: prefer pkg_check_modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,10 @@ endif()
 
 find_package(PkgConfig QUIET)
 
-find_package(OpenSSL)
+pkg_check_modules(OPENSSL openssl)
 
 if (NOT OPENSSL_FOUND)
-    pkg_check_modules(OPENSSL openssl)
+    find_package(OpenSSL)
 endif()
 
 find_package(WolfSSL)


### PR DESCRIPTION
Prefer `pkg_check_modules` over `find_package` to avoid the following static build failure with openssl and `-latomic`:

```
/home/autobuild/autobuild/instance-8/output-1/host/lib/gcc/sparc-buildroot-linux-uclibc/10.4.0/../../../../sparc-buildroot-linux-uclibc/bin/ld: /home/autobuild/autobuild/instance-8/output-1/host/sparc-buildroot-linux-uclibc/sysroot/usr/lib/libssl.a(ssl_cert.o): in function `ssl_cert_free':
ssl_cert.c:(.text+0x53c): undefined reference to `__atomic_fetch_sub_4'
```

Fixes:
 - http://autobuild.buildroot.org/results/f606bb15bf4f88ba29ef0795413e13acc9cd0976