### PR TITLE
Add SSL mode ACCEPT_MOVING_WRITE_BUFFER for {Open,Wolf}SSL

### DIFF
--- a/openssl.c
+++ b/openssl.c
@@ -160,6 +160,9 @@ struct ssl_context *ssl_context_new(bool server)
         return NULL;
 
     SSL_CTX_set_verify(c, SSL_VERIFY_NONE, NULL);
+#if defined(SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER)
+    SSL_CTX_set_mode(c, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
+#endif
 
     SSL_CTX_set_options(c, SSL_OP_NO_COMPRESSION | SSL_OP_SINGLE_ECDH_USE | SSL_OP_CIPHER_SERVER_PREFERENCE);
 #if defined(SSL_CTX_set_ecdh_auto) && OPENSSL_VERSION_NUMBER < 0x10100000L


### PR DESCRIPTION
Avoid SSL error 'Bad write retry' after pending SSL write and buffer reclaim.

When a buffer fills considerably, so that SSL_write eventually stops with an SSL_ERROR_WANT_WRITE, a buffer reclaim may happen before the next call to SSL_write, and so the address of the buffer passed to the OpenSSL library may have changed. The following error can be observed. A closer look to the error queue reveals a SSL_R_BAD_WRITE_RETRY fault.

(uwsc.c:462) ssl_write(1): error:00000001:lib(0):func(0):reason(1)

This produces an error with the default configuration of OpenSSL, unless the ACCEPT_MOVING_WRITE_BUFFER mode is activated. For WolfSSL this seems to be the default (src/ssl.c).