### PR TITLE
CMakeLists.txt: remove -Werror from CFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(SSL_SUPPORT)
 
     add_library(xssl STATIC ${SSL_SRC})
     target_compile_definitions(xssl PRIVATE ${SSL_DEFINE})
-    target_compile_options(xssl PRIVATE -O -Wall -Werror --std=gnu99 -fPIC)
+    target_compile_options(xssl PRIVATE -O -Wall --std=gnu99 -fPIC)
     target_include_directories(xssl PRIVATE ${SSL_INC})
     target_link_libraries(xssl PRIVATE ${SSL_LIBS})
 


### PR DESCRIPTION
Build is broken with OpenSSL 3.0, see buildroot autobuilder logs: http://autobuild.buildroot.net/results/c09/c09c77e399e9ee410995a91a22306897eca667d1/build-end.log

/home/autobuild/autobuild/instance-2/output-1/build/libuhttpd-3.14.1/src/ssl/openssl.c:
 In function 'ssl_last_error_string':
/home/autobuild/autobuild/instance-2/output-1/build/libuhttpd-3.14.1/src/ssl/openssl.c:143:9:
 error: 'ERR_peek_error_line_data' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]

cc1: all warnings being treated as errors